### PR TITLE
Use `#'` instead of single quote

### DIFF
--- a/term-project.el
+++ b/term-project.el
@@ -63,13 +63,13 @@
 (defun term-project-switch (&rest args)
   "Switch terms in the current project.
 ARGS is passed to `term-manager-display-term'."
-  (apply 'term-manager-display-term term-project-term-manager args))
+  (apply #'term-manager-display-term term-project-term-manager args))
 
 (defun term-project-global-switch (&rest args)
   "Switch terms globally.
 ARGS is passed to `term-manager-get-next-global-buffer'."
   (let ((default-directory term-project-global-directory))
-    (term-manager-display-buffer (apply 'term-manager-get-next-global-buffer
+    (term-manager-display-buffer (apply #'term-manager-get-next-global-buffer
                                         term-project-term-manager args))))
 
 (defun term-project-get-all-buffers ()
@@ -80,7 +80,7 @@ ARGS is passed to `term-manager-get-next-global-buffer'."
 (defun term-project-select-existing ()
   "Select `project-term' buffer in the current project."
   (completing-read "Select a term buffer: "
-                   (mapcar 'buffer-name
+                   (mapcar #'buffer-name
                            (term-project-get-all-buffers))))
 
 ;;;###autoload

--- a/term-projectile.el
+++ b/term-projectile.el
@@ -58,11 +58,11 @@
 (defconst term-projectile-term-manager (term-projectile))
 
 (defun term-projectile-switch (&rest args)
-  (apply 'term-manager-display-term term-projectile-term-manager args))
+  (apply #'term-manager-display-term term-projectile-term-manager args))
 
 (defun term-projectile-global-switch (&rest args)
   (let ((default-directory term-projectile-global-directory))
-    (term-manager-display-buffer (apply 'term-manager-get-next-global-buffer
+    (term-manager-display-buffer (apply #'term-manager-get-next-global-buffer
                                         term-projectile-term-manager args))))
 
 (defun term-projectile-get-all-buffers ()
@@ -71,7 +71,7 @@
 
 (defun term-projectile-select-existing ()
   (completing-read "Select a term buffer: "
-                   (mapcar 'buffer-name
+                   (mapcar #'buffer-name
                            (term-projectile-get-all-buffers))))
 
 ;;;###autoload


### PR DESCRIPTION
Sorry for my successive PRs.
This PR replace some quote for functions with `#'` to fix the melpazoid warnings:

`term-project.el` with [melpazoid](https://github.com/riscy/melpazoid):
```
- term-project.el#L66: It's safer to sharp-quote function names; use `#'`
- term-project.el#L72: It's safer to sharp-quote function names; use `#'`
- term-project.el#L83: It's safer to sharp-quote function names; use `#'`
```
